### PR TITLE
Fix import path for upload_file_to_s3

### DIFF
--- a/src/image.py
+++ b/src/image.py
@@ -4,7 +4,7 @@ import os
 import base64
 import io
 
-from src.upload_image import upload_file_to_s3
+from upload_image import upload_file_to_s3
 
 # Import environment variables
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")


### PR DESCRIPTION
The latest image tag doesn't include support for arm64

So building for myself `docker compose build` completes, but on creation fails with `ModuleNotFoundError: No module named 'src'`

```yaml
services:
  media_creator:
    build:
     context: .
    container_name: mcp-media-creator
    restart: always
    ports:
      - "8961:8961"
    environment:
      AWS_REGION: us-east-1
      S3_BUCKET: libre-mcp-media-creator
```

can be reproduced with `python src/run_sse.py` 