### PR TITLE
Fix annoying boto usage

### DIFF
--- a/src/image.py
+++ b/src/image.py
@@ -9,8 +9,7 @@ from upload_image import upload_file_to_s3
 # Import environment variables
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 MODEL_ID = "amazon.nova-canvas-v1:0"
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
 
 async def create_image(prompt,negative_prompt, quality, width, height, seed_value):
     """

--- a/src/image.py
+++ b/src/image.py
@@ -26,7 +26,7 @@ async def create_image(prompt,negative_prompt, quality, width, height, seed_valu
     """
 
     # Initiate Bedrock Client
-    bedrock = boto3.client("bedrock-runtime", region_name=AWS_REGION, aws_access_key_id=AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+    bedrock = boto3.client("bedrock-runtime", region_name=AWS_REGION)
 
     # Set picture parameters
     model_input = json.dumps({

--- a/src/upload_image.py
+++ b/src/upload_image.py
@@ -27,14 +27,13 @@ def upload_file_to_s3(file_object):
     aws_region= os.environ['AWS_REGION']
     aws_bucket = os.environ["S3_BUCKET"]
 
-    if not aws_bucket or not aws_region or not aws_access_key_id or not aws_secret_access_key:
+    if not aws_bucket or not aws_region:
         raise NoCredentialsError()
 
     object_name = generate_unique_object_name()
 
     # Create an S3 client
-    s3_client = boto3.client('s3', region_name=aws_region, aws_access_key_id= aws_access_key_id,
-    aws_secret_access_key= aws_secret_access_key, endpoint_url=f'https://s3.{aws_region}.amazonaws.com')
+    s3_client = boto3.client('s3', region_name=aws_region)
 
     try:
         # Upload the file to S3

--- a/src/upload_image.py
+++ b/src/upload_image.py
@@ -22,8 +22,6 @@ def upload_file_to_s3(file_object):
     :param file_object: File-like object to upload
     :return: Pre-signed URL string if successful, else None
     """
-    aws_access_key_id = os.environ["AWS_ACCESS_KEY"]
-    aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
     aws_region= os.environ['AWS_REGION']
     aws_bucket = os.environ["S3_BUCKET"]
 

--- a/src/video.py
+++ b/src/video.py
@@ -6,8 +6,7 @@ import os
 MODEL_ID = "amazon.nova-reel-v1:0"
 S3_DESTINATION_BUCKET = os.environ.get("S3_BUCKET")
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
 
 async def create_video(prompt):
     """
@@ -18,7 +17,7 @@ async def create_video(prompt):
     """
 
     # Initiate Bedrock Client
-    bedrock_runtime = boto3.client("bedrock-runtime", region_name=AWS_REGION, aws_access_key_id =AWS_ACCESS_KEY_ID, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+    bedrock_runtime = boto3.client("bedrock-runtime", region_name=AWS_REGION)
 
     # Set video parameters
     model_input = {
@@ -44,9 +43,7 @@ async def create_video(prompt):
     s3_prefix = invocation_arn.split('/')[-1]
 
     # Initiate S3 Client
-    s3_client = boto3.client('s3', region_name=AWS_REGION, aws_access_key_id=AWS_ACCESS_KEY_ID,
-                             aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-                             endpoint_url=f'https://s3.{AWS_REGION}.amazonaws.com')
+    s3_client = boto3.client('s3', region_name=AWS_REGION)
 
     # Get pre-signed URL for the video to be generated
     url = s3_client.generate_presigned_url('get_object',


### PR DESCRIPTION
Theres no point in initializing the client like this, and super annoying in real world for people that don't pass keys. You get all these for free. The config is overloading these well-known environment var to manually pass through a signature.

It's also asserting `NoCredentialsError()`,  which makes debugging super confusing because it's not even true, let aws raise that error.


```
AWS_ACCESS_KEY_ID
The access key for your AWS account.

AWS_SECRET_ACCESS_KEY
The secret key for your AWS account.

AWS_SESSION_TOKEN
The session key for your AWS account. This is only needed when you are using temporary credentials. The AWS_SECURITY_TOKEN environment variable can also be used, but is only supported for backward-compatibility purposes. AWS_SESSION_TOKEN is supported by multiple AWS SDKs in addition to Boto3.

AWS_DEFAULT_REGION
The default AWS Region to use, for example, us-west-1 or us-west-2.

AWS_PROFILE
The default profile to use, if any. If no value is specified, Boto3 attempts to search the shared credentials file and the config file for the default profile.

AWS_CONFIG_FILE
The location of the config file used by Boto3. By default this value is ~/.aws/config. You only need to set this variable if you want to change this location.

AWS_SHARED_CREDENTIALS_FILE
The location of the shared credentials file. By default this value is ~/.aws/credentials. You only need to set this variable if you want to change this location.

BOTO_CONFIG
The location of the Boto2 credentials file. This is not set by default. You only need to set this variable if you want to use credentials stored in Boto2 format in a location other than /etc/boto.cfg or ~/.boto.

AWS_CA_BUNDLE
The path to a custom certificate bundle to use when establishing SSL/TLS connections. Boto3 includes a CA bundle that it uses by default, but you can set this environment variable to use a different CA bundle.

AWS_METADATA_SERVICE_TIMEOUT
The number of seconds before a connection to the instance metadata service should time out. When attempting to retrieve credentials on an Amazon EC2 instance that is configured with an IAM role, a connection to the instance metadata service will time out after 1 second by default. If you know you’re running on an EC2 instance with an IAM role configured, you can increase this value if needed.

AWS_METADATA_SERVICE_NUM_ATTEMPTS
When attempting to retrieve credentials on an Amazon EC2 instance that has been configured with an IAM role, Boto3 will make only one attempt to retrieve credentials from the instance metadata service before giving up. If you know your code will be running on an EC2 instance, you can increase this value to make Boto3 retry multiple times before giving up.

AWS_DATA_PATH
A list of additional directories to check when loading botocore data. You typically don’t need to set this value. There are two built-in search paths: <botocoreroot>/data/ and ~/.aws/models. Setting this environment variable indicates additional directories to check first before falling back to the built-in search paths. Multiple entries should be separated with the os.pathsep character, which is : on Linux and ; on Windows.

AWS_STS_REGIONAL_ENDPOINTS
Sets AWS STS endpoint resolution logic. See the sts_regional_endpoints configuration file section for more information on how to use this.

AWS_MAX_ATTEMPTS
The total number of attempts made for a single request. For more information, see the max_attempts configuration file section.

AWS_RETRY_MODE
Specifies the types of retries the SDK will use. For more information, see the retry_mode configuration file section.

AWS_SDK_UA_APP_ID
AppId is an optional application specific identifier that can be set. When set it will be appended to the User-Agent header of every request in the form of App/{AppId}.

AWS_SIGV4A_SIGNING_REGION_SET
A comma-delimited list of regions to sign when signing with SigV4a. For more information, see the sigv4a_signing_region_set configuration file section.

AWS_REQUEST_CHECKSUM_CALCULATION
Determines when a checksum will be calculated for request payloads. For more information, see the request_checksum_calculation configuration file section.

AWS_RESPONSE_CHECKSUM_VALIDATION
Determines when checksum validation will be performed on response payloads. For more information, see the response_checksum_validation configuration file section.
```